### PR TITLE
correction on confusion matrix calculation

### DIFF
--- a/Day1_Introduction/5. Datascience workflow with pandas and scikit-learn.ipynb
+++ b/Day1_Introduction/5. Datascience workflow with pandas and scikit-learn.ipynb
@@ -898,7 +898,7 @@
    },
    "outputs": [],
    "source": [
-    "print(confmat.astype(np.float64) / confmat.sum(axis=1))"
+    "print(confmat.astype(np.float64) / confmat.sum(axis=1).reshape((2,1)))"
    ]
   },
   {


### PR DESCRIPTION
confmat is (2,2)
confmat.sum(axis=1) returns an array (2,)
when an operation is done with confmat.sum(axis=1) it is interpreted as (1,2) for each line of confmat
the result is 
array([[ 0.89090909,  0.17391304],
       [ 0.32727273,  0.47826087]])
which does not even sum 1 along the lines

with the .reshape((2,1)), it is ensured an operation between (2,2) and (2,1)
this will do the division of each column by the vector